### PR TITLE
Fix Multi-Place location URL

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -58,7 +58,7 @@
     {
       "name": "Multi-Place",
       "category": "Convenience",
-      "location": "https://raw.githubusercontent.com/lnjustin/Multi-Place/main/packageManifest.json",
+      "location": "https://raw.githubusercontent.com/lnjustin/Multi-Place/master/packageManifest.json",
       "description": "Automate based on current traffic conditions from Google Traffic. Use a single dashboard tile to represent your location, no matter where you are.",
       "tags": [
         "Vehicles & Transportation",

--- a/repository.json
+++ b/repository.json
@@ -58,7 +58,7 @@
     {
       "name": "Multi-Place",
       "category": "Convenience",
-      "location": "https://raw.githubusercontent.com/lnjustin/Lift-Off/main/packageManifest.json",
+      "location": "https://raw.githubusercontent.com/lnjustin/Multi-Place/main/packageManifest.json",
       "description": "Automate based on current traffic conditions from Google Traffic. Use a single dashboard tile to represent your location, no matter where you are.",
       "tags": [
         "Vehicles & Transportation",


### PR DESCRIPTION
A quick fix to the location URL for Multi-place, which is currently pointing to the Lift Off repository and making it impossible to install either through HPM.